### PR TITLE
Use openjfx's javafx artifacts to get it working on Java 11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,41 @@ this works fairly well already (Xmx 3GB, 8GB heap dump):
 ![Type reference view](https://github.com/yawkat/hdr/blob/screenshots/S0ps.png?raw=true)
 
 ![Thread details (WIP)](https://github.com/yawkat/hdr/blob/screenshots/oYRc.png?raw=true)
+
+JPMS
+----
+
+To run on Java 9+, you'll need to configure the JVM to allow access to JavaFX modules:
+
+```
+--add-opens
+javafx.graphics/com.sun.javafx.util=ALL-UNNAMED
+--add-opens
+javafx.base/com.sun.javafx.reflect=ALL-UNNAMED
+--add-opens
+javafx.base/com.sun.javafx.beans=ALL-UNNAMED
+--add-opens
+javafx.graphics/com.sun.javafx.scene.layout=ALL-UNNAMED
+--add-opens
+javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
+--add-opens
+javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED
+--add-opens
+javafx.graphics/com.sun.javafx.scene.text=ALL-UNNAMED
+--add-opens
+javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED
+--add-opens
+javafx.base/com.sun.javafx.logging=ALL-UNNAMED
+--add-opens
+javafx.base/com.sun.javafx.collections=ALL-UNNAMED
+--add-opens
+javafx.base/com.sun.javafx.event=ALL-UNNAMED
+--add-opens
+javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED
+--add-opens
+javafx.graphics/com.sun.javafx.stage=ALL-UNNAMED
+--add-opens
+javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED
+--add-opens
+javafx.base/com.sun.javafx=ALL-UNNAMED
+```

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,12 +15,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.7</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>net.sf.trove4j</groupId>
@@ -36,12 +31,6 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.9</version>
-        </dependency>
-
-        <dependency>
-            <groupId>at.yawk.logging</groupId>
-            <artifactId>logging-jul</artifactId>
-            <version>1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -27,6 +27,33 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gui/src/main/java/at/yawk/hdr/gui/Main.java
+++ b/gui/src/main/java/at/yawk/hdr/gui/Main.java
@@ -1,16 +1,12 @@
 package at.yawk.hdr.gui;
 
-import at.yawk.logging.jul.FormatterBuilder;
-import at.yawk.logging.jul.Loggers;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javafx.application.Application;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
  * @author yawkat
@@ -31,14 +27,8 @@ public class Main extends Application {
     }
 
     private void prepareLogging() {
-        Logger root = Logger.getLogger("");
-        ConsoleHandler handler = new ConsoleHandler();
-        handler.setFormatter(
-                FormatterBuilder.create().build()
-        );
-        handler.setLevel(Level.FINE);
-        root.setLevel(handler.getLevel());
-        Loggers.replaceHandlers(root, handler);
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
     }
 
     private static Path expandShell(Path path) {

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <slf4j.version>1.7.26</slf4j.version>
+        <javafx.version>11.0.2</javafx.version>
     </properties>
 
     <repositories>
@@ -28,7 +31,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.14.8</version>
+            <version>1.18.8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
There were references to logging classes that haven't been published.
The code lives in https://github.com/yawkat/logging, but without
artifacts it couldn't be used, so I changed it to use slf4j-simple
instead.